### PR TITLE
Feature - add type inference for `on()`, `off()` and `emit()`

### DIFF
--- a/src/types/eventData.ts
+++ b/src/types/eventData.ts
@@ -1,0 +1,60 @@
+import { CbEvents } from '..';
+import {
+  BlackUserItem,
+  ConversationItem,
+  FriendApplicationItem,
+  FriendUserItem,
+  GroupApplicationItem,
+  GroupItem,
+  GroupMemberItem,
+  MessageItem,
+  ReceiptInfo,
+  RevokedInfo,
+  SelfUserInfo,
+  UserOnlineState,
+} from './entity';
+
+export type EventDataMap = {
+  [CbEvents.OnProgress]: number;
+  [CbEvents.OnBlackAdded]: BlackUserItem;
+  [CbEvents.OnBlackDeleted]: BlackUserItem;
+  [CbEvents.OnConversationChanged]: ConversationItem;
+  [CbEvents.OnFriendAdded]: FriendUserItem;
+  [CbEvents.OnFriendApplicationAdded]: FriendApplicationItem;
+  [CbEvents.OnFriendApplicationDeleted]: FriendApplicationItem;
+  [CbEvents.OnFriendApplicationRejected]: FriendApplicationItem;
+  [CbEvents.OnFriendDeleted]: FriendUserItem;
+  [CbEvents.OnFriendInfoChanged]: FriendUserItem;
+  [CbEvents.OnGroupApplicationAdded]: GroupApplicationItem;
+  [CbEvents.OnGroupApplicationDeleted]: GroupApplicationItem;
+  [CbEvents.OnGroupApplicationRejected]: GroupApplicationItem;
+  [CbEvents.OnGroupApplicationAccepted]: GroupApplicationItem;
+  [CbEvents.OnGroupDismissed]: GroupItem;
+  [CbEvents.OnGroupMemberDeleted]: GroupMemberItem;
+  [CbEvents.OnGroupMemberInfoChanged]: GroupMemberItem;
+  [CbEvents.OnJoinedGroupAdded]: GroupItem;
+  [CbEvents.OnJoinedGroupDeleted]: GroupItem;
+  [CbEvents.OnNewConversation]: ConversationItem[];
+  [CbEvents.OnNewRecvMessageRevoked]: RevokedInfo;
+  [CbEvents.OnRecvC2CReadReceipt]: ReceiptInfo[];
+  [CbEvents.OnRecvGroupReadReceipt]: ReceiptInfo[];
+  [CbEvents.OnRecvNewMessage]: MessageItem;
+  [CbEvents.OnRecvNewMessages]: MessageItem[];
+  [CbEvents.OnRecvOfflineNewMessage]: MessageItem;
+  [CbEvents.OnRecvOfflineNewMessages]: MessageItem[];
+  [CbEvents.OnSelfInfoUpdated]: SelfUserInfo;
+  [CbEvents.OnSyncServerFailed]: void;
+  [CbEvents.OnSyncServerStart]: void;
+  [CbEvents.OnSyncServerFinish]: void;
+  [CbEvents.OnTotalUnreadMessageCountChanged]: number;
+  [CbEvents.OnUserStatusChanged]: UserOnlineState;
+  [CbEvents.OnConnectFailed]: void;
+  [CbEvents.OnConnectSuccess]: void;
+  [CbEvents.OnConnecting]: void;
+  [CbEvents.OnKickedOffline]: void;
+  [CbEvents.OnUserTokenExpired]: void;
+};
+
+export type DataOfEvent<E extends CbEvents> = E extends keyof EventDataMap
+  ? EventDataMap[E]
+  : never;

--- a/src/utils/emitter.ts
+++ b/src/utils/emitter.ts
@@ -1,11 +1,12 @@
 import { WSEvent } from '@/types/entity';
 import { CbEvents } from '../constant';
+import { DataOfEvent } from '../types/eventData';
 
 interface Events {
-  [key: string]: Cbfn[];
+  [key: string]: Cbfn<any>[];
 }
 
-type Cbfn = (data: WSEvent<any>) => void;
+type Cbfn<E extends CbEvents> = (data: WSEvent<DataOfEvent<E>>) => void;
 
 class Emitter {
   private events: Events;
@@ -14,7 +15,7 @@ class Emitter {
     this.events = {};
   }
 
-  emit(event: CbEvents, data: WSEvent) {
+  emit<E extends CbEvents>(event: E, data: WSEvent<DataOfEvent<E>>) {
     if (this.events[event]) {
       this.events[event].forEach(fn => {
         return fn(data);
@@ -24,7 +25,7 @@ class Emitter {
     return this;
   }
 
-  on(event: CbEvents, fn: Cbfn) {
+  on<E extends CbEvents>(event: E, fn: Cbfn<E>) {
     if (this.events[event]) {
       this.events[event].push(fn);
     } else {
@@ -34,7 +35,7 @@ class Emitter {
     return this;
   }
 
-  off(event: CbEvents, fn: Cbfn) {
+  off<E extends CbEvents>(event: E, fn: Cbfn<E>) {
     if (event && typeof fn === 'function' && this.events[event]) {
       const listeners = this.events[event];
       if (!listeners || listeners.length === 0) {


### PR DESCRIPTION
#### 🅰 Please add the issue ID after "Fixes #"
Fixes #86 

I wrote the very simple version to infer the data types of different event. 
However, I found the callbacks on the [official docs](https://docs.openim.io/sdks/callback) seems different from all the `CbEvents` I found in the code.

Can anyone help define the remaining callbacks in `EventDataMap`?