### PR TITLE
fix: typo for enums that should be "normal"

### DIFF
--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -95,7 +95,7 @@ export enum SessionType {
 }
 export enum GroupStatus {
   Normal = 0,
-  Baned = 1,
+  Banned = 1,
   Dismissed = 2,
   Muted = 3,
 }
@@ -128,6 +128,6 @@ export enum OnlineState {
   Offline = 0,
 }
 export enum GroupMessageReaderFilter {
-  Readed = 0,
+  Read = 0,
   UnRead = 1,
 }

--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -1,5 +1,5 @@
 export enum MessageReceiveOptType {
-  Nomal = 0,
+  Normal = 0,
   NotReceive = 1,
   NotNotify = 2,
 }
@@ -17,7 +17,7 @@ export enum GroupJoinSource {
   QrCode = 4,
 }
 export enum GroupMemberRole {
-  Nomal = 20,
+  Normal = 20,
   Admin = 60,
   Owner = 100,
 }
@@ -94,7 +94,7 @@ export enum SessionType {
   Notification = 4,
 }
 export enum GroupStatus {
-  Nomal = 0,
+  Normal = 0,
   Baned = 1,
   Dismissed = 2,
   Muted = 3,
@@ -110,8 +110,8 @@ export enum GroupMemberFilter {
   All = 0,
   Owner = 1,
   Admin = 2,
-  Nomal = 3,
-  AdminAndNomal = 4,
+  Normal = 3,
+  AdminAndNormal = 4,
   AdminAndOwner = 5,
 }
 export enum Relationship {


### PR DESCRIPTION
Fix some little typos of enum declarations.
